### PR TITLE
fix: TypeScript build errors for Vercel deployment

### DIFF
--- a/src/components/AppLayout/AppLayout.tsx
+++ b/src/components/AppLayout/AppLayout.tsx
@@ -272,26 +272,10 @@ const AppLayoutContent: React.FC<AppLayoutContentProps> = ({
             ? [
                 {
                   id: 'insights',
-                  label: (
-                    <Stack direction="row" spacing="xs" align="center">
-                      <Typography variant="body" size="md" weight="medium">
-                        Insights
-                      </Typography>
-                      <Stack 
-                        className="px-2 py-0.5 bg-spotify-green rounded-full animate-pulse"
-                        align="center"
-                        justify="center"
-                      >
-                        <Typography variant="caption" size="xs" weight="bold" className="text-black leading-none">
-                          NEW
-                        </Typography>
-                      </Stack>
-                    </Stack>
-                  ),
+                  label: 'Insights ✨',
                   onClick: () => router.push('/insights'),
-                  variant: 'text' as const,
+                  variant: 'primary' as const,
                   type: 'button' as const,
-                  className: 'hover:text-spotify-green transition-colors',
                 },
                 {
                   id: 'logout',

--- a/src/components/TrackDetailModal/TrackDetailModal.tsx
+++ b/src/components/TrackDetailModal/TrackDetailModal.tsx
@@ -104,7 +104,7 @@ export const TrackDetailModal: React.FC<TrackDetailModalProps> = ({ isOpen, onCl
             {track.album && (
               <Stack direction="row" spacing="sm" align="center">
                 <Icon icon={faCompactDisc} size="sm" color="#95E1D3" />
-                <Stack direction="column" spacing="none" className="flex-1">
+                <Stack direction="column" spacing="xs" className="flex-1">
                   <Typography variant="body" size="sm" color="secondary">
                     Album
                   </Typography>
@@ -119,7 +119,7 @@ export const TrackDetailModal: React.FC<TrackDetailModalProps> = ({ isOpen, onCl
             {releaseYear && (
               <Stack direction="row" spacing="sm" align="center">
                 <Icon icon={faCalendar} size="sm" color="#FFA07A" />
-                <Stack direction="column" spacing="none" className="flex-1">
+                <Stack direction="column" spacing="xs" className="flex-1">
                   <Typography variant="body" size="sm" color="secondary">
                     Release Year
                   </Typography>
@@ -134,7 +134,7 @@ export const TrackDetailModal: React.FC<TrackDetailModalProps> = ({ isOpen, onCl
             {track.track_number && (
               <Stack direction="row" spacing="sm" align="center">
                 <Icon icon={faMusic} size="sm" color="#C77DFF" />
-                <Stack direction="column" spacing="none" className="flex-1">
+                <Stack direction="column" spacing="xs" className="flex-1">
                   <Typography variant="body" size="sm" color="secondary">
                     Track Number
                   </Typography>
@@ -148,7 +148,7 @@ export const TrackDetailModal: React.FC<TrackDetailModalProps> = ({ isOpen, onCl
             {/* Explicit */}
             {track.explicit !== undefined && (
               <Stack direction="row" spacing="sm" align="center">
-                <Stack direction="column" spacing="none" className="flex-1">
+                <Stack direction="column" spacing="xs" className="flex-1">
                   <Typography variant="body" size="sm" color="secondary">
                     Content Rating
                   </Typography>

--- a/src/types/spotify.ts
+++ b/src/types/spotify.ts
@@ -52,6 +52,8 @@ export interface SpotifyTrack {
     name: string;
     images: SpotifyImage[];
     id?: string;
+    release_date?: string;
+    total_tracks?: number;
   };
   duration_ms: number;
   preview_url?: string | null;
@@ -61,6 +63,7 @@ export interface SpotifyTrack {
   };
   uri?: string;
   popularity?: number; // 0-100 popularity score from Spotify
+  track_number?: number;
 }
 
 export interface SpotifyTrackWithContext {


### PR DESCRIPTION
🐛 Fixed Build Errors:
- Changed Typography size from 'xs' to 'sm' (valid values: sm|md|lg|xl|xxl|2xl)
- Simplified Insights button label to string 'Insights ✨' with primary variant
- Removed custom className prop from HeaderAction (not supported)
- Added missing properties to SpotifyTrack album type: • release_date • total_tracks
- Added track_number to SpotifyTrack interface
- Changed Stack spacing from 'none' to 'xs' (valid values: xs|sm|md|lg)

All TypeScript errors resolved. Build now succeeds! ✅